### PR TITLE
Orders

### DIFF
--- a/hni-admin-service/src/main/java/org/hni/admin/service/OrderController.java
+++ b/hni-admin-service/src/main/java/org/hni/admin/service/OrderController.java
@@ -1,7 +1,15 @@
 package org.hni.admin.service;
 
-import java.time.LocalDate;
-import java.util.Collection;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.apache.commons.lang3.StringUtils;
+import org.hni.common.DateUtils;
+import org.hni.order.om.Order;
+import org.hni.order.service.OrderService;
+import org.hni.user.om.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
 import javax.ws.rs.DELETE;
@@ -12,18 +20,8 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-
-import org.apache.commons.lang3.StringUtils;
-import org.hni.common.DateUtils;
-import org.hni.order.om.Order;
-import org.hni.order.service.OrderService;
-import org.hni.user.om.User;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
-
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
+import java.time.LocalDate;
+import java.util.Collection;
 
 @Api(value = "/orders", description = "Operations on Orders and OrderItems")
 @Component

--- a/hni-order/src/main/java/org/hni/order/dao/DefaultOrderDAO.java
+++ b/hni-order/src/main/java/org/hni/order/dao/DefaultOrderDAO.java
@@ -1,19 +1,20 @@
 package org.hni.order.dao;
 
-import java.time.LocalDate;
-import java.util.Collection;
-import java.util.Collections;
-
-import javax.persistence.NoResultException;
-import javax.persistence.Query;
-
 import org.hni.common.DateUtils;
 import org.hni.common.dao.AbstractDAO;
 import org.hni.order.om.Order;
+import org.hni.provider.om.ProviderLocation;
 import org.hni.user.om.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+
+import javax.persistence.NoResultException;
+import javax.persistence.Query;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Collections;
 
 @Component
 public class DefaultOrderDAO extends AbstractDAO<Order> implements OrderDAO {
@@ -24,17 +25,32 @@ public class DefaultOrderDAO extends AbstractDAO<Order> implements OrderDAO {
 	}
 
 	@Override
-	public Collection<Order> get(User user, LocalDate startDate, LocalDate endDate) {
+	public Collection<Order> get(User user, LocalDate fromDate, LocalDate toDate) {
 		try {
-			Query q = em.createQuery("SELECT x FROM Order x WHERE x.userId = :userId AND x.orderDate BETWEEN :startDate AND :endDate")
+			Query q = em.createQuery("SELECT x FROM Order x WHERE x.userId = :userId AND x.orderDate BETWEEN :fromDate AND :toDate")
 				.setParameter("userId", user.getId())
-				.setParameter("startDate", DateUtils.asDate(startDate))
-				.setParameter("endDate", DateUtils.asDate(endDate));
+				.setParameter("fromDate", DateUtils.asDate(fromDate))
+				.setParameter("toDate", DateUtils.asDate(toDate));
 			return q.getResultList();
 		} catch(NoResultException e) {
 			return Collections.emptyList();
 		}
 	}
 
+	@Override
+	public Collection<Order> get(ProviderLocation providerLocation, LocalDateTime fromDate, LocalDateTime toDate) {
+		try {
+			Query q = em.createQuery("SELECT x FROM Order x "
+					+ "WHERE x.orderDate BETWEEN :fromDate AND :toDate "
+					+ "AND x.providerLocation = :providerLocationId "
+					+ "ORDER By orderDate")
+					.setParameter("providerLocationId", providerLocation)
+					.setParameter("fromDate", DateUtils.asDate(fromDate))
+					.setParameter("toDate", DateUtils.asDate(toDate));
+			return q.getResultList();
+		} catch (NoResultException e) {
+			return Collections.emptyList();
+		}
+	}
 
 }

--- a/hni-order/src/main/java/org/hni/order/dao/DefaultOrderDAO.java
+++ b/hni-order/src/main/java/org/hni/order/dao/DefaultOrderDAO.java
@@ -42,8 +42,7 @@ public class DefaultOrderDAO extends AbstractDAO<Order> implements OrderDAO {
 		try {
 			Query q = em.createQuery("SELECT x FROM Order x "
 					+ "WHERE x.orderDate BETWEEN :fromDate AND :toDate "
-					+ "AND x.providerLocation = :providerLocationId "
-					+ "ORDER By orderDate")
+					+ "AND x.providerLocation = :providerLocationId ")
 					.setParameter("providerLocationId", providerLocation)
 					.setParameter("fromDate", DateUtils.asDate(fromDate))
 					.setParameter("toDate", DateUtils.asDate(toDate));

--- a/hni-order/src/main/java/org/hni/order/dao/OrderDAO.java
+++ b/hni-order/src/main/java/org/hni/order/dao/OrderDAO.java
@@ -1,13 +1,19 @@
 package org.hni.order.dao;
 
-import java.time.LocalDate;
-import java.util.Collection;
-
 import org.hni.common.dao.BaseDAO;
 import org.hni.order.om.Order;
+import org.hni.provider.om.ProviderLocation;
 import org.hni.user.om.User;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Date;
 
 public interface OrderDAO extends BaseDAO<Order> {
 
-	Collection<Order> get(User user, LocalDate startDate, LocalDate endDate);
+	public Collection<Order> get(User user, LocalDate fromDate, LocalDate toDate);
+
+	Collection<Order> get(ProviderLocation providerLocation, LocalDateTime fromDate, LocalDateTime toDate);
+
 }

--- a/hni-order/src/main/java/org/hni/order/dao/OrderDAO.java
+++ b/hni-order/src/main/java/org/hni/order/dao/OrderDAO.java
@@ -8,11 +8,10 @@ import org.hni.user.om.User;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collection;
-import java.util.Date;
 
 public interface OrderDAO extends BaseDAO<Order> {
 
-	public Collection<Order> get(User user, LocalDate fromDate, LocalDate toDate);
+	Collection<Order> get(User user, LocalDate fromDate, LocalDate toDate);
 
 	Collection<Order> get(ProviderLocation providerLocation, LocalDateTime fromDate, LocalDateTime toDate);
 

--- a/hni-order/src/main/java/org/hni/order/service/DefaultOrderService.java
+++ b/hni-order/src/main/java/org/hni/order/service/DefaultOrderService.java
@@ -64,7 +64,11 @@ public class DefaultOrderService extends AbstractService<Order> implements Order
 	public Order next(ProviderLocation providerLocation, LocalDateTime fromDate) {
 		// Returns an uncompleted order placed with the provided time window.  Null if none found.
 		List<Order> orders = (ArrayList) orderDao.get(providerLocation, fromDate, LocalDateTime.now());
-		return orders.get(0);
+		return orders.stream()
+				.filter(order -> order.getPickupDate() == null)
+				.sorted((order1, order2) -> Long.compare(order1.getOrderDate().getTime(), order2.getOrderDate().getTime()))
+				.findFirst()
+				.orElse(null);
 	}
 
 	@Override

--- a/hni-order/src/main/java/org/hni/order/service/DefaultOrderService.java
+++ b/hni-order/src/main/java/org/hni/order/service/DefaultOrderService.java
@@ -1,21 +1,24 @@
 package org.hni.order.service;
 
-import java.time.LocalDate;
-import java.util.Collection;
-import java.util.Date;
-
-import javax.inject.Inject;
-
 import org.hni.common.service.AbstractService;
 import org.hni.order.dao.OrderDAO;
 import org.hni.order.om.Order;
-import org.hni.provider.om.Provider;
+import org.hni.provider.om.ProviderLocation;
 import org.hni.user.om.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.inject.Inject;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
 
 @Component
 @Transactional(propagation = Propagation.REQUIRED, rollbackFor = Exception.class)
@@ -52,27 +55,16 @@ public class DefaultOrderService extends AbstractService<Order> implements Order
 	}
 
 	@Override
-	public Order next(LocalDate orderDate) {
-		// TODO Auto-generated method stub
-		return null;
+	public Order next(ProviderLocation providerLocation) {
+		// Returns an uncompleted order placed within the last 24 hours. Null if none found.
+		return next(providerLocation, LocalDateTime.now().minus(1, ChronoUnit.DAYS));
 	}
 
 	@Override
-	public Order next() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public Order next(Provider provider, LocalDate orderDate) {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public Order next(Provider provider) {
-		// TODO Auto-generated method stub
-		return null;
+	public Order next(ProviderLocation providerLocation, LocalDateTime fromDate) {
+		// Returns an uncompleted order placed with the provided time window.  Null if none found.
+		List<Order> orders = (ArrayList) orderDao.get(providerLocation, fromDate, LocalDateTime.now());
+		return orders.get(0);
 	}
 
 	@Override

--- a/hni-order/src/main/java/org/hni/order/service/OrderService.java
+++ b/hni-order/src/main/java/org/hni/order/service/OrderService.java
@@ -1,12 +1,14 @@
 package org.hni.order.service;
 
-import java.time.LocalDate;
-import java.util.Collection;
-
 import org.hni.common.service.BaseService;
 import org.hni.order.om.Order;
-import org.hni.provider.om.Provider;
+import org.hni.provider.om.ProviderLocation;
 import org.hni.user.om.User;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Date;
 
 public interface OrderService extends BaseService<Order> {
 
@@ -43,33 +45,20 @@ public interface OrderService extends BaseService<Order> {
 	Order release(Order order);
 	
 	/**
-	 * Gets the next order to process where the order was created on a date
-	 * @param orderDate
-	 * @return
-	 */
-	Order next(LocalDate orderDate);
-	
-	/**
-	 * Returns the next available order.
-	 * @return
-	 */
-	Order next();
-	
-	/**
 	 * Gets the next available order to process for a particular provider
 	 * where the order was created on a date.
-	 * @param provider
+	 * @param providerLocation
 	 * @param orderDate
 	 * @return
 	 */
-	Order next(Provider provider, LocalDate orderDate);
+	Order next(ProviderLocation providerLocation, LocalDateTime orderDate);
 	
 	/**
 	 * Returns the next available order for a provider
-	 * @param provider
+	 * @param providerLocation
 	 * @return
 	 */
-	Order next(Provider provider);
+	Order next(ProviderLocation providerLocation);
 	
 	/**
 	 * Sets an order to completed.

--- a/hni-order/src/test/java/org/hni/order/dao/TestDefaultOrderDAO.java
+++ b/hni-order/src/test/java/org/hni/order/dao/TestDefaultOrderDAO.java
@@ -6,6 +6,7 @@ import org.hni.provider.om.ProviderLocation;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,7 @@ import java.util.List;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations={"classpath:test-applicationContext.xml"} )
 @Transactional
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class TestDefaultOrderDAO {
 
     @Inject

--- a/hni-order/src/test/java/org/hni/order/dao/TestDefaultOrderDAO.java
+++ b/hni-order/src/test/java/org/hni/order/dao/TestDefaultOrderDAO.java
@@ -6,7 +6,6 @@ import org.hni.provider.om.ProviderLocation;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,7 +23,6 @@ import java.util.List;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations={"classpath:test-applicationContext.xml"} )
 @Transactional
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class TestDefaultOrderDAO {
 
     @Inject

--- a/hni-order/src/test/java/org/hni/order/dao/TestDefaultOrderDAO.java
+++ b/hni-order/src/test/java/org/hni/order/dao/TestDefaultOrderDAO.java
@@ -39,10 +39,16 @@ public class TestDefaultOrderDAO {
         }
 
         List<Order> orders = (ArrayList<Order>) orderDao.get(new ProviderLocation(2L), LocalDateTime.now().minus(1, ChronoUnit.DAYS), LocalDateTime.now());
+
+        //Verifies that the correct list of orders was returned
         Assert.assertEquals(5, orders.size());
         for (Order order : orders) {
             Assert.assertEquals(new Long(2L), order.getProviderLocation().getId());
         }
+
+        //Verifies that orders were not returned when search parameters were bad
+        orders = (ArrayList<Order>) orderDao.get(new ProviderLocation(9L), LocalDateTime.now().minus(1, ChronoUnit.DAYS), LocalDateTime.now());
+        Assert.assertEquals(0, orders.size());
     }
 
 }

--- a/hni-order/src/test/java/org/hni/order/dao/TestDefaultOrderDAO.java
+++ b/hni-order/src/test/java/org/hni/order/dao/TestDefaultOrderDAO.java
@@ -1,0 +1,48 @@
+package org.hni.order.dao;
+
+import org.hni.order.om.Order;
+import org.hni.order.service.OrderTestData;
+import org.hni.provider.om.ProviderLocation;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.inject.Inject;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Verifies that the dao is making successful queries
+ */
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations={"classpath:test-applicationContext.xml"} )
+@Transactional
+public class TestDefaultOrderDAO {
+
+    @Inject
+    private OrderDAO orderDao;
+
+    @Test
+    public void testGetByProvider() {
+        LocalDateTime now = LocalDateTime.now();
+
+        for (int i = 0; i < 5; i ++) {
+            orderDao.save(OrderTestData.getTestOrder(now.minus(i, ChronoUnit.MINUTES), new ProviderLocation(1L)));
+            orderDao.save(OrderTestData.getTestOrder(now.minus(i, ChronoUnit.MINUTES), new ProviderLocation(2L)));
+            orderDao.save(OrderTestData.getTestOrder(now.minus(i, ChronoUnit.MINUTES), new ProviderLocation(3L)));
+        }
+
+        List<Order> orders = (ArrayList<Order>) orderDao.get(new ProviderLocation(2L), LocalDateTime.now().minus(1, ChronoUnit.DAYS), LocalDateTime.now());
+        Assert.assertEquals(5, orders.size());
+        for (Order order : orders) {
+            Assert.assertEquals(new Long(2L), order.getProviderLocation().getId());
+        }
+    }
+
+}

--- a/hni-order/src/test/java/org/hni/order/service/OrderTestData.java
+++ b/hni-order/src/test/java/org/hni/order/service/OrderTestData.java
@@ -1,28 +1,33 @@
 package org.hni.order.service;
 
+import org.hni.common.DateUtils;
 import org.hni.order.om.Order;
 import org.hni.order.om.OrderItem;
 import org.hni.provider.om.MenuItem;
 import org.hni.provider.om.ProviderLocation;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 /**
- * Created by chugh13 on 11/6/16.
+ * Test data to be used for TestOrderService
  */
 public class OrderTestData {
 
     public static Order getTestOrder() {
+        return getTestOrder(LocalDateTime.now(), new ProviderLocation(1L));
+    }
+
+    public static Order getTestOrder(LocalDateTime date, ProviderLocation providerLocation) {
         Order order = new Order();
 
         order.setCreatedById(1L);
-        order.setOrderDate(new Date());
-        order.setProviderLocation( new ProviderLocation(1L));
+        order.setOrderDate(DateUtils.asDate(date));
+        order.setProviderLocation(providerLocation);
         order.getOrderItems().add(new OrderItem(1L, 8.99, new MenuItem(1L)));
         order.getOrderItems().add(new OrderItem(2L, 7.99, new MenuItem(2L)));
 
         return order;
     }
-
 
 }

--- a/hni-order/src/test/java/org/hni/order/service/TestOrderService.java
+++ b/hni-order/src/test/java/org/hni/order/service/TestOrderService.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations={"classpath:test-applicationContext.xml"} )
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @Transactional
 public class TestOrderService {
 	
@@ -55,21 +55,20 @@ public class TestOrderService {
 
 	@Test
 	public void testOrderComplete() {
-		Order order = OrderTestData.getTestOrder();
+		Date pickupDate = new Date();
 
+		Order order = OrderTestData.getTestOrder();
 		// Checks that the pickup date is null prior to the completion methods
 		assertEquals(null, order.getPickupDate());
 
-		Date pickupDate = new Date();
 		Order returnOrder = orderService.complete(order);
-
 		// Verifies that the pickup date has been updated
-		assertTrue(returnOrder.getPickupDate().after(pickupDate));
+		assertTrue(pickupDate.before(returnOrder.getPickupDate()));
 
 		//Checks that it was properly loaded into database
 		Order orderFromDatabase = orderService.get(order.getId());
 		assertNotNull(orderFromDatabase);
-		assertTrue(orderFromDatabase.getPickupDate().after(pickupDate));
+		assertTrue(pickupDate.before(orderFromDatabase.getPickupDate()));
 	}
 
 	@Test

--- a/hni-order/src/test/java/org/hni/order/service/TestOrderService.java
+++ b/hni-order/src/test/java/org/hni/order/service/TestOrderService.java
@@ -14,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.inject.Inject;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Date;
@@ -72,7 +71,7 @@ public class TestOrderService {
 	}
 
 	@Test
-	public void testNextOrder() {
+	public void testNextOrder_Success() {
 		LocalDateTime fromDate = LocalDateTime.now().minus(12, ChronoUnit.HOURS);
 
 		//Loads 10 orders into database with two different providers and orders offset by 1 hour
@@ -92,4 +91,22 @@ public class TestOrderService {
 		}
 
 	}
+
+	@Test
+	public void testNextOrder_InvalidDate() {
+		//Places orders 12 hours into the future
+		LocalDateTime fromDate = LocalDateTime.now().plus(12, ChronoUnit.HOURS);
+
+		//Loads 10 orders into database with two different providers and orders offset by 1 hour
+		for (int i = 0; i < 5; i ++) {
+			orderService.save(OrderTestData.getTestOrder(fromDate.minus(i, ChronoUnit.MINUTES), new ProviderLocation(1L)));
+			orderService.save(OrderTestData.getTestOrder(fromDate.minus(i, ChronoUnit.MINUTES), new ProviderLocation(2L)));
+		}
+
+		//Search from tomorrow to today (backwards)
+		Order order = orderService.next(new ProviderLocation(1L), LocalDateTime.now().plus(1, ChronoUnit.DAYS));
+		//No object should be returned for searches in the future
+		assertNull(order);
+	}
+
 }

--- a/hni-order/src/test/java/org/hni/order/service/TestOrderService.java
+++ b/hni-order/src/test/java/org/hni/order/service/TestOrderService.java
@@ -1,9 +1,8 @@
 package org.hni.order.service;
 
 import org.apache.log4j.BasicConfigurator;
+import org.hni.common.DateUtils;
 import org.hni.order.om.Order;
-import org.hni.order.om.OrderItem;
-import org.hni.provider.om.MenuItem;
 import org.hni.provider.om.ProviderLocation;
 import org.hni.user.om.User;
 import org.junit.Test;
@@ -14,19 +13,20 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.inject.Inject;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Date;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations={"classpath:test-applicationContext.xml"} )
 @Transactional
 public class TestOrderService {
 	
-	@Inject private OrderService orderService;
+	@Inject
+	private OrderService orderService;
 	
 	public TestOrderService() {
 		BasicConfigurator.configure();
@@ -55,7 +55,7 @@ public class TestOrderService {
 	public void testOrderComplete() {
 		Order order = OrderTestData.getTestOrder();
 
-		// Checks that the pickup date is null prior to the completion methos
+		// Checks that the pickup date is null prior to the completion methods
 		assertEquals(null, order.getPickupDate());
 
 		Date pickupDate = new Date();
@@ -68,6 +68,20 @@ public class TestOrderService {
 		Order orderFromDatabase = orderService.get(order.getId());
 		assertNotNull(orderFromDatabase);
 		assertTrue(orderFromDatabase.getPickupDate().after(pickupDate));
+	}
 
+	@Test
+	public void testNextOrder() {
+		LocalDateTime now = LocalDateTime.now();
+		//Loads 10 orders into database with two different providers and orders offset by 1 hour
+		for (int i = 0; i < 5; i ++) {
+			orderService.save(OrderTestData.getTestOrder(now.minus(i, ChronoUnit.MINUTES), new ProviderLocation(1L)));
+			orderService.save(OrderTestData.getTestOrder(now.minus(i, ChronoUnit.MINUTES), new ProviderLocation(2L)));
+		}
+
+		Order order = orderService.next(new ProviderLocation(1L));
+
+		assertTrue(order.getOrderDate().before(DateUtils.asDate(LocalDateTime.now())));
+		assertEquals(new Long(1L) , order.getProviderLocation().getId());
 	}
 }

--- a/hni-order/src/test/java/org/hni/order/service/TestOrderService.java
+++ b/hni-order/src/test/java/org/hni/order/service/TestOrderService.java
@@ -7,6 +7,7 @@ import org.hni.provider.om.ProviderLocation;
 import org.hni.user.om.User;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +23,7 @@ import static org.junit.Assert.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations={"classpath:test-applicationContext.xml"} )
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @Transactional
 public class TestOrderService {
 	
@@ -99,12 +101,12 @@ public class TestOrderService {
 
 		//Loads 10 orders into database with two different providers and orders offset by 1 hour
 		for (int i = 0; i < 5; i ++) {
-			orderService.save(OrderTestData.getTestOrder(fromDate.minus(i, ChronoUnit.MINUTES), new ProviderLocation(1L)));
-			orderService.save(OrderTestData.getTestOrder(fromDate.minus(i, ChronoUnit.MINUTES), new ProviderLocation(2L)));
+			orderService.save(OrderTestData.getTestOrder(fromDate.minus(i, ChronoUnit.MINUTES), new ProviderLocation(10L)));
+			orderService.save(OrderTestData.getTestOrder(fromDate.minus(i, ChronoUnit.MINUTES), new ProviderLocation(20L)));
 		}
 
 		//Search from tomorrow to today (backwards)
-		Order order = orderService.next(new ProviderLocation(1L), LocalDateTime.now().plus(1, ChronoUnit.DAYS));
+		Order order = orderService.next(new ProviderLocation(10L), LocalDateTime.now().plus(1, ChronoUnit.DAYS));
 		//No object should be returned for searches in the future
 		assertNull(order);
 	}

--- a/hni-order/src/test/java/org/hni/order/service/TestOrderService.java
+++ b/hni-order/src/test/java/org/hni/order/service/TestOrderService.java
@@ -7,7 +7,6 @@ import org.hni.provider.om.ProviderLocation;
 import org.hni.user.om.User;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +22,6 @@ import static org.junit.Assert.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations={"classpath:test-applicationContext.xml"} )
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @Transactional
 public class TestOrderService {
 	
@@ -57,18 +55,20 @@ public class TestOrderService {
 	public void testOrderComplete() {
 		Date pickupDate = new Date();
 
-		Order order = OrderTestData.getTestOrder();
+		Order order = OrderTestData.getTestOrder(LocalDateTime.now() ,new ProviderLocation(99L));
 		// Checks that the pickup date is null prior to the completion methods
 		assertEquals(null, order.getPickupDate());
 
 		Order returnOrder = orderService.complete(order);
 		// Verifies that the pickup date has been updated
-		assertTrue(pickupDate.before(returnOrder.getPickupDate()));
+		assertTrue(pickupDate.before(returnOrder.getPickupDate())
+				|| pickupDate.getTime() == returnOrder.getPickupDate().getTime());
 
 		//Checks that it was properly loaded into database
 		Order orderFromDatabase = orderService.get(order.getId());
-		assertNotNull(orderFromDatabase);
-		assertTrue(pickupDate.before(orderFromDatabase.getPickupDate()));
+		assertNotNull(orderFromDatabase.getPickupDate());
+		assertTrue(pickupDate.before(orderFromDatabase.getPickupDate())
+				|| pickupDate.getTime() == orderFromDatabase.getPickupDate().getTime());
 	}
 
 	@Test


### PR DESCRIPTION
Added the next() functionality to the DeafultOrdersService.  Some notes about design choices.

1) I made the next require ProviderLocation in order to prevent a Waffle House in Maine for making the order produced for Missouri.

2) I removed the next() and next(LocalDate) as it would be impossible to determine which provider needs to fulfill the order based off that information alone.

3) I used LocalDateTime through the call in order to have time based sort functionality (i.e. give preference to older order on the same day) and to allow for searching within specified time windows as opposed to only date windows.

4) I changed the filed parameters in the OrderDAO module to make them more readable in their SQL Query.

5) I reorganized imports liberally.