### PR TITLE
Resolve 105 - create multiple orders if users requests more meals for family

### DIFF
--- a/hni-order/src/main/java/org/hni/order/dao/DefaultPartialOrderDAO.java
+++ b/hni-order/src/main/java/org/hni/order/dao/DefaultPartialOrderDAO.java
@@ -14,7 +14,7 @@ import java.util.List;
  * The DAO for PartialOrders
  */
 @Component
-public class DefaultPartialOrderDAO extends AbstractDAO {
+public class DefaultPartialOrderDAO extends AbstractDAO<PartialOrder> {
     public DefaultPartialOrderDAO() {
         super(PartialOrder.class);
     }

--- a/hni-order/src/main/java/org/hni/order/om/PartialOrder.java
+++ b/hni-order/src/main/java/org/hni/order/om/PartialOrder.java
@@ -1,9 +1,10 @@
 package org.hni.order.om;
 
-import org.hni.common.om.Persistable;
-import org.hni.provider.om.MenuItem;
-import org.hni.provider.om.ProviderLocation;
-import org.hni.user.om.User;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -17,11 +18,10 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import org.hni.common.om.Persistable;
+import org.hni.provider.om.MenuItem;
+import org.hni.provider.om.ProviderLocation;
+import org.hni.user.om.User;
 
 /**
  * Provides a state holder during ordering session.
@@ -61,7 +61,7 @@ public class PartialOrder implements Persistable, Serializable {
             joinColumns = @JoinColumn( name="id"),
             inverseJoinColumns = @JoinColumn( name="menu_item_id")
     )
-    private Set<MenuItem> menuItemsSelected;
+    private Collection<MenuItem> menuItemsSelected;
 
     @ManyToOne
     @JoinColumn(name="chosen_provider_id", referencedColumnName = "id")
@@ -76,7 +76,7 @@ public class PartialOrder implements Persistable, Serializable {
     public PartialOrder() {
         this.providerLocationsForSelection = new ArrayList<>();
         this.menuItemsForSelection = new ArrayList<>();
-        this.menuItemsSelected = new HashSet<>();
+        this.menuItemsSelected = new ArrayList<>();
     }
 
     @Override
@@ -136,7 +136,7 @@ public class PartialOrder implements Persistable, Serializable {
         this.address = address;
     }
 
-    public Set<MenuItem> getMenuItemsSelected() {
+    public Collection<MenuItem> getMenuItemsSelected() {
         return menuItemsSelected;
     }
 

--- a/hni-order/src/main/java/org/hni/order/om/TransactionPhase.java
+++ b/hni-order/src/main/java/org/hni/order/om/TransactionPhase.java
@@ -9,6 +9,7 @@ public enum TransactionPhase {
     PROVIDING_ADDRESS,
     CHOOSING_LOCATION,
     CHOOSING_MENU_ITEM,
-    CONFIRM_OR_REDO
+    CONFIRM_OR_REDO,
+    MULTIPLE_ORDER
 
 }

--- a/hni-order/src/main/java/org/hni/order/service/DefaultOrderProcessor.java
+++ b/hni-order/src/main/java/org/hni/order/service/DefaultOrderProcessor.java
@@ -1,7 +1,19 @@
 package org.hni.order.service;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
 import org.apache.commons.lang.StringUtils;
-import org.hni.common.exception.HNIException;
 import org.hni.events.service.EventRouter;
 import org.hni.events.service.om.Event;
 import org.hni.events.service.om.EventName;
@@ -16,28 +28,13 @@ import org.hni.provider.om.Menu;
 import org.hni.provider.om.MenuItem;
 import org.hni.provider.om.ProviderLocation;
 import org.hni.provider.service.ProviderLocationService;
+import org.hni.security.om.ActivationCode;
+import org.hni.security.service.ActivationCodeService;
 import org.hni.user.dao.UserDAO;
 import org.hni.user.om.User;
-import org.joda.time.DateTime;
-import org.joda.time.Period;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalUnit;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Component
 public class DefaultOrderProcessor implements OrderProcessor {
@@ -57,6 +54,8 @@ public class DefaultOrderProcessor implements OrderProcessor {
 	public static String REPLY_ORDER_REQUEST_ADDRESS = "Reply with your location (e.g. #3 Smith St. 72758) or ENDMEAL to quit";
     public static String REPLY_PROVIDERS_UNAVAILABLE = "Providers currently unavailable. Reply with new location or try again later. Reply ENDMEAL to quit. ";
     public static String REPLY_NO_PROVIDERS = "There are no providers near your location. Reply with new location or ENDMEAL to quit.";
+    // In this flow, user chooses meal here : Reply 1) Ham sandwich 2) Tacos 3) Chicken Salad
+    public static String REPLY_MULTIPLE_ORDERS = "You can order up to %d meals. How many would you like?";
     public static String REPLY_CONFIRM_ORDER = "You've chosen %s at %s. Reply CONFIRM to place this order, REDO to try again or ENDMEAL to quit.";
     public static String REPLY_ORDER_COMPLETE = "Success! Order confirmed. Reply with STATUS after 5 minutes to check to status of your order.";
     public static String REPLY_NEED_VALID_RESPONSE = "Please respond with CONFIRM, REDO, or ENDMEAL";
@@ -64,7 +63,7 @@ public class DefaultOrderProcessor implements OrderProcessor {
     public static String REPLY_ORDER_READY = "Your order has been placed and should be ready to pick up shortly from %s at %s %s.";
     public static String REPLY_ORDER_CLOSED = "Your order has been marked as closed.";
     public static String REPLY_ORDER_NOT_FOUND = "I can't find a recent order for you, please reply MEAL to place an order.";
-    
+
     public static String REPLY_ORDER_ITEM = "%d) %s from %s %s %s. ";
     public static String REPLY_ORDER_CHOICE = "Reply %s to choose your meal. ";
     
@@ -84,6 +83,8 @@ public class DefaultOrderProcessor implements OrderProcessor {
 
     @Inject
     private OrderService orderService;
+    @Inject
+    private ActivationCodeService activationCodeService;
 
     @Inject
     private EventRouter eventRouter;
@@ -137,11 +138,14 @@ public class DefaultOrderProcessor implements OrderProcessor {
                 output = findNearbyMeals(message, order);
                 break;
             case CHOOSING_LOCATION:
-                output = chooseLocation(message, order);
+                output = chooseLocation(user, message, order);
                 break;
             case CHOOSING_MENU_ITEM:
                 //this is chosen w/ provider for now
                 break;
+            case MULTIPLE_ORDER:
+            	handleMultipleOrders(user, message, order);
+            	break;
             case CONFIRM_OR_REDO:
                 return confirmOrContinueOrder(message, order);
             default:
@@ -200,7 +204,7 @@ public class DefaultOrderProcessor implements OrderProcessor {
     }
 
 
-    private String chooseLocation(String message, PartialOrder order) {
+    private String chooseLocation(User user, String message, PartialOrder order) {
         String output = "";
         try {
             int index = Integer.parseInt(message);
@@ -212,8 +216,17 @@ public class DefaultOrderProcessor implements OrderProcessor {
             MenuItem chosenItem = order.getMenuItemsForSelection().get(index - 1);
             order.getMenuItemsSelected().add(chosenItem);
             logger.debug("Location {} has been chosen with item {}", location.getName(), chosenItem.getName());
-            order.setTransactionPhase(TransactionPhase.CONFIRM_OR_REDO);
-            output = String.format(REPLY_CONFIRM_ORDER, chosenItem.getName(), location.getName());
+            
+            // If this user has multiple auth codes we'll want to ask them how many of this item 
+            List<ActivationCode> activationCodes = activationCodeService.getByUser(user);
+            if (activationCodes.size() > 1) {
+                order.setTransactionPhase(TransactionPhase.MULTIPLE_ORDER);
+                output = String.format(REPLY_MULTIPLE_ORDERS, activationCodes.size());
+            }
+            else {
+	            order.setTransactionPhase(TransactionPhase.CONFIRM_OR_REDO);
+	            output = String.format(REPLY_CONFIRM_ORDER, chosenItem.getName(), location.getName());
+            }
         } catch (NumberFormatException | IndexOutOfBoundsException e) {
             output += REPLY_INVALID_INPUT;
             output += providerLocationMenuOutput(order);
@@ -221,6 +234,39 @@ public class DefaultOrderProcessor implements OrderProcessor {
         return output;
     }
 
+    private String handleMultipleOrders(User user, String message, PartialOrder order) {
+    	String output = "" ;
+    	
+    	int num = Integer.parseInt(message);
+    	
+    	List<ActivationCode> activationCodes = activationCodeService.getByUser(user);
+    	logger.debug("# activationCodes=" + activationCodes.size());
+    	if (num == 0) {
+			logger.info("Reset order choices for PartialOrder {} by user request", order.getId());
+			//clear out previous choices
+			output = findNearbyMeals(order.getAddress(), order);
+    	}
+    	else {
+    		if (num > activationCodes.size()) {
+	    		// Too many - order them the maximum and move on
+    			logger.debug("User requested more meals than they have. Req=" + num + " actual=" + activationCodes.size());
+	    		num = activationCodes.size();
+    		}
+	 		Collection<MenuItem> menuItems = order.getMenuItemsSelected();
+			MenuItem menuItem = menuItems.iterator().next();
+			
+	 		for (int x=0; x < num-1; x++) {
+	 			logger.debug("Adding menuItem to partialOrder");
+				menuItems.add(menuItem);
+			}
+	 		// Set next phase to confirm order
+	 		order.setTransactionPhase(TransactionPhase.CONFIRM_OR_REDO);
+	 		output = REPLY_CONFIRM_ORDER;
+    	}
+		partialOrderDAO.save(order);
+		return output;
+
+    }
     private String confirmOrContinueOrder(String message, PartialOrder order) {
         String output = "";
         
@@ -231,7 +277,7 @@ public class DefaultOrderProcessor implements OrderProcessor {
                 finalOrder.setOrderDate(new Date());
                 finalOrder.setProviderLocation(order.getChosenProvider());
                 //set items being ordered
-                Set<MenuItem> chosenItems = order.getMenuItemsSelected();
+                Collection<MenuItem> chosenItems = order.getMenuItemsSelected();
                 Set<OrderItem> orderedItems = chosenItems.stream().map(mItem -> new OrderItem(1L, mItem.getPrice(), mItem))
                         .collect(Collectors.toSet());
                 orderedItems.forEach(item -> item.setOrder(finalOrder));

--- a/hni-order/src/main/java/org/hni/order/service/DefaultOrderProcessor.java
+++ b/hni-order/src/main/java/org/hni/order/service/DefaultOrderProcessor.java
@@ -237,11 +237,17 @@ public class DefaultOrderProcessor implements OrderProcessor {
     private String handleMultipleOrders(User user, String message, PartialOrder order) {
     	String output = "" ;
     	
-    	int num = Integer.parseInt(message);
+    	int num;
+		try {
+			num = Integer.parseInt(message);
+		} catch (NumberFormatException e) {
+			// if they can't type in a valid number, set to ZERO and next phase is REDO
+			num = 0;
+		}
     	
     	List<ActivationCode> activationCodes = activationCodeService.getByUser(user);
     	logger.debug("# activationCodes=" + activationCodes.size());
-    	if (num == 0) {
+    	if (num <= 0) {
 			logger.info("Reset order choices for PartialOrder {} by user request", order.getId());
 			//clear out previous choices
 			output = findNearbyMeals(order.getAddress(), order);

--- a/hni-order/src/test/java/org/hni/order/service/TestDefaultOrderProcessorService.java
+++ b/hni-order/src/test/java/org/hni/order/service/TestDefaultOrderProcessorService.java
@@ -374,4 +374,86 @@ public class TestDefaultOrderProcessorService {
         Assert.assertEquals(DefaultOrderProcessor.REPLY_NO_UNDERSTAND, output);
     }
 
+    @Test
+    public void processMessage_multipleOrders_Exact() {
+        // Setup
+    	User user = new User(); 
+    	
+        user.setId(10L);
+        partialOrder.setUser(user);
+        partialOrder.setTransactionPhase(TransactionPhase.MULTIPLE_ORDER);
+        partialOrder.setProviderLocationsForSelection(providerLocationList);
+        partialOrder.setMenuItemsForSelection(menuItems);
+        partialOrder.setAddress("home");
+        partialOrder.setChosenProvider(providerLocationList.get(1));       
+        partialOrder.getMenuItemsSelected().add(menuItems.get(0));
+         
+        Mockito.when(partialOrderDAO.byUser(user)).thenReturn(partialOrder);
+        Mockito.when(providerLocationService.providersNearCustomer(Mockito.anyString(), Mockito.anyInt(), Mockito.anyDouble()
+                , Mockito.anyDouble()))
+                .thenReturn(providerLocationList);
+        Date orderDate = new Date();
+        // Execute
+        String message = "3";  // user requested 3 meals and has 3 activation codes
+        String output = orderProcessor.processMessage(user, message);
+        
+        // Expected output is meals were duplicated
+        logger.debug("PartialOrder #items=" + partialOrder.getMenuItemsSelected().size());
+        Assert.assertTrue((partialOrder.getMenuItemsSelected().size() == 3));
+    }
+
+    public void processMessage_multipleOrders_MoreThanAuthCodes() {
+        // Setup
+    	User user = new User(); 
+    	
+        user.setId(10L);
+        partialOrder.setUser(user);
+        partialOrder.setTransactionPhase(TransactionPhase.MULTIPLE_ORDER);
+        partialOrder.setProviderLocationsForSelection(providerLocationList);
+        partialOrder.setMenuItemsForSelection(menuItems);
+        partialOrder.setAddress("home");
+        partialOrder.setChosenProvider(providerLocationList.get(1));       
+        partialOrder.getMenuItemsSelected().add(menuItems.get(0));
+         
+        Mockito.when(partialOrderDAO.byUser(user)).thenReturn(partialOrder);
+        Mockito.when(providerLocationService.providersNearCustomer(Mockito.anyString(), Mockito.anyInt(), Mockito.anyDouble()
+                , Mockito.anyDouble()))
+                .thenReturn(providerLocationList);
+        Date orderDate = new Date();
+        // Execute
+        String message = "5";  // user requested 5 meals and has 3 activation codes
+        String output = orderProcessor.processMessage(user, message);
+        
+        // Expected output is meals were duplicated
+        logger.debug("PartialOrder #items=" + partialOrder.getMenuItemsSelected().size());
+        Assert.assertTrue((partialOrder.getMenuItemsSelected().size() == 3));
+    }
+
+    public void processMessage_multipleOrders_LessThanAuthCodes() {
+        // Setup
+    	User user = new User(); 
+    	
+        user.setId(10L);
+        partialOrder.setUser(user);
+        partialOrder.setTransactionPhase(TransactionPhase.MULTIPLE_ORDER);
+        partialOrder.setProviderLocationsForSelection(providerLocationList);
+        partialOrder.setMenuItemsForSelection(menuItems);
+        partialOrder.setAddress("home");
+        partialOrder.setChosenProvider(providerLocationList.get(1));       
+        partialOrder.getMenuItemsSelected().add(menuItems.get(0));
+         
+        Mockito.when(partialOrderDAO.byUser(user)).thenReturn(partialOrder);
+        Mockito.when(providerLocationService.providersNearCustomer(Mockito.anyString(), Mockito.anyInt(), Mockito.anyDouble()
+                , Mockito.anyDouble()))
+                .thenReturn(providerLocationList);
+        Date orderDate = new Date();
+        // Execute
+        String message = "1";  // user requested 5 meals and has 3 activation codes
+        String output = orderProcessor.processMessage(user, message);
+        
+        // Expected output is meals were duplicated
+        logger.debug("PartialOrder #items=" + partialOrder.getMenuItemsSelected().size());
+        Assert.assertTrue((partialOrder.getMenuItemsSelected().size() == 1));
+    }
+
 }

--- a/hni-order/src/test/java/org/hni/order/service/TestDefaultOrderProcessorService.java
+++ b/hni-order/src/test/java/org/hni/order/service/TestDefaultOrderProcessorService.java
@@ -456,4 +456,32 @@ public class TestDefaultOrderProcessorService {
         Assert.assertTrue((partialOrder.getMenuItemsSelected().size() == 1));
     }
 
+    @Test
+    public void processMessage_multipleOrders_InvalidNumber() {
+        // Setup
+    	User user = new User(); 
+    	
+        user.setId(10L);
+        partialOrder.setUser(user);
+        partialOrder.setTransactionPhase(TransactionPhase.MULTIPLE_ORDER);
+        partialOrder.setProviderLocationsForSelection(providerLocationList);
+        partialOrder.setMenuItemsForSelection(menuItems);
+        partialOrder.setAddress("home");
+        partialOrder.setChosenProvider(providerLocationList.get(1));       
+        partialOrder.getMenuItemsSelected().add(menuItems.get(0));
+         
+        Mockito.when(partialOrderDAO.byUser(user)).thenReturn(partialOrder);
+        Mockito.when(providerLocationService.providersNearCustomer(Mockito.anyString(), Mockito.anyInt(), Mockito.anyDouble()
+                , Mockito.anyDouble()))
+                .thenReturn(providerLocationList);
+        Date orderDate = new Date();
+        // Execute
+        String message = "ONE";  // user sent invalid data and has 3 activation codes
+        String output = orderProcessor.processMessage(user, message);
+        
+        // Expected output is meals were duplicated
+        logger.debug("PartialOrder #items=" + partialOrder.getMenuItemsSelected().size());
+        Assert.assertTrue((partialOrder.getMenuItemsSelected().size() == 1));
+    }
+
 }

--- a/hni-schema/src/test/resources/hsql/test-data.sql
+++ b/hni-schema/src/test/resources/hsql/test-data.sql
@@ -124,6 +124,7 @@ insert into activation_codes values(4, '987654', 2, 10, 10, 0, null, now(), null
 insert into activation_codes values(5, 'x1987654', 2, 10, 10, 1, 'test for no more meals', now(), 9);
 insert into activation_codes values(6, 'y1987654', 2, 10, 10, 1, 'test for more meals', now(), 10);
 insert into activation_codes values(7, 'z1987654', 2, 10, 10, 1, 'test for more meals', now(), 10);
+insert into activation_codes values(8, 'a1987654', 2, 10, 10, 1, 'test for more meals', now(), 10);
 
 truncate table addresses;
 insert into addresses values (1, 'subway corp addr', '1251 Phoenician way', '', 'columbus','oh','43240', -82.98402279999999, 40.138686,'etc');

--- a/hni-security/src/main/java/org/hni/security/dao/DefaultActivationCodeDAO.java
+++ b/hni-security/src/main/java/org/hni/security/dao/DefaultActivationCodeDAO.java
@@ -34,7 +34,7 @@ public class DefaultActivationCodeDAO extends AbstractDAO<ActivationCode> implem
 	@Override
 	public List<ActivationCode> getByUser(User user) {
 		try {
-			Query q = em.createQuery("SELECT x FROM ActivationCode x WHERE x.user.id = :userId AND x.mealsRemaining > 0")
+			Query q = em.createQuery("SELECT x FROM ActivationCode x WHERE x.user.id = :userId AND x.mealsRemaining > 0 AND x.enabled = true")
 				.setParameter("userId", user.getId());
 			return q.getResultList();
 		} catch (NoResultException e) {


### PR DESCRIPTION
If user has more than 1 auth code, system will go into new transaction phase to ask how many meals.
If they respond with 0 or fewer it goes to REDO.
If they request less than they have, it only adds how many they requested and moves to confirm.
If they request more than they have, it sets to max adds the additional meals and moves to confirm.
