### PR TITLE
Updated maxDailyOrdersReached method to check for orders all day. Thi…

### DIFF
--- a/hni-order/src/main/java/org/hni/order/service/DefaultOrderService.java
+++ b/hni-order/src/main/java/org/hni/order/service/DefaultOrderService.java
@@ -179,7 +179,7 @@ public class DefaultOrderService extends AbstractService<Order> implements Order
 	public boolean maxDailyOrdersReached(User user) {
 		List<ActivationCode> activeActivationCodes = activationCodeService.getByUser(user);
 		LocalDateTime startDate = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0); //.minus(Duration.ofHours(mealOffset));
-		LocalDateTime endDate = LocalDateTime.now();
+		LocalDateTime endDate = LocalDateTime.now().withHour(23).withMinute(59).withSecond(59);  // set duration to be all all day
  		
 		logger.debug("#codes=" + activeActivationCodes.size());
     	for(ActivationCode ac : activeActivationCodes) {


### PR DESCRIPTION
…s accomodates orders in different timezones and test data with specific times.

Also resolves hni-order failing tests at specific times of the day due. Test data has order created at 11:30am and tests ran prior to this time were failing. This change sets start time to 00:00:00 and end time to 23:59:59 to find orders. 