### PR TITLE
151 Check if there are pending orders before allowing MEAL workflow to begin

### DIFF
--- a/hni-order/src/main/java/org/hni/order/service/DefaultOrderProcessor.java
+++ b/hni-order/src/main/java/org/hni/order/service/DefaultOrderProcessor.java
@@ -75,6 +75,7 @@ public class DefaultOrderProcessor implements OrderProcessor {
     public static String REPLY_INVALID_INPUT = "Invalid input! ";
     public static String REPLY_EXCEPTION_REGISTER_FIRST = "You will need to reply with REGISTER to sign up first.";
     public static String REPLY_MAX_ORDERS_REACHED = "You've reached the maximum number of orders for today. Please come back tomorrow.";
+    public static String REPLY_CURRENT_PENDING_ORDER = "You currently have an open order. Please wait until that order has been completed to place another.";
     private static final RemoteInvocationOptions REDISSON_REMOTE_INVOCATION_OPTION =
             RemoteInvocationOptions.defaults().expectAckWithin(10, TimeUnit.SECONDS).noResult();
 
@@ -116,6 +117,8 @@ public class DefaultOrderProcessor implements OrderProcessor {
 
             if (orderService.maxDailyOrdersReached(user)) {
                 return REPLY_MAX_ORDERS_REACHED;
+            } else if (orderService.currentPendingOrder(user)) {
+                return REPLY_CURRENT_PENDING_ORDER;
             }
             order = new PartialOrder();
             order.setTransactionPhase(TransactionPhase.MEAL);

--- a/hni-order/src/main/java/org/hni/order/service/DefaultOrderProcessor.java
+++ b/hni-order/src/main/java/org/hni/order/service/DefaultOrderProcessor.java
@@ -115,10 +115,10 @@ public class DefaultOrderProcessor implements OrderProcessor {
             return REPLY_NOT_CURRENTLY_ORDERING;
         } else if (order == null && !message.equalsIgnoreCase(MSG_STATUS)) {
 
-            if (orderService.maxDailyOrdersReached(user)) {
-                return REPLY_MAX_ORDERS_REACHED;
-            } else if (orderService.currentPendingOrder(user)) {
+            if (orderService.currentPendingOrder(user)) {
                 return REPLY_CURRENT_PENDING_ORDER;
+            } else if (orderService.maxDailyOrdersReached(user)) {
+                return REPLY_MAX_ORDERS_REACHED;
             }
             order = new PartialOrder();
             order.setTransactionPhase(TransactionPhase.MEAL);

--- a/hni-order/src/main/java/org/hni/order/service/DefaultOrderService.java
+++ b/hni-order/src/main/java/org/hni/order/service/DefaultOrderService.java
@@ -197,6 +197,20 @@ public class DefaultOrderService extends AbstractService<Order> implements Order
 	}
 
 	/**
+	 * Determines if the user has an order that has not yet been fulfilled.
+	 * @param user
+	 * @return
+	 */
+	@Override
+	public boolean currentPendingOrder(User user) {
+		LocalDateTime startDate = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0); //.minus(Duration.ofHours(mealOffset));
+		LocalDateTime endDate = LocalDateTime.now().withHour(23).withMinute(59).withSecond(59);  // set duration to be all all day
+		Collection<Order> todaysOrders = orderDao.get(user, startDate, endDate);
+
+		return todaysOrders.stream().anyMatch(order -> order.getOrderStatus() == OrderStatus.OPEN);
+	}
+
+	/**
 	 * Returns true if the user has one or more valid and active activation codes.
 	 * @param user
 	 * @return

--- a/hni-order/src/main/java/org/hni/order/service/OrderService.java
+++ b/hni-order/src/main/java/org/hni/order/service/OrderService.java
@@ -76,6 +76,13 @@ public interface OrderService extends BaseService<Order> {
 	 * @return
 	 */
 	public boolean maxDailyOrdersReached(User user);
+
+	/**
+	 * Returns true if the user has a current open order
+	 * @param user
+	 * @return
+	 */
+	public boolean currentPendingOrder(User user);
 	
 	/**
 	 * Returns true if the user has one or more active authorization codes (not expired or used up)

--- a/hni-order/src/test/java/org/hni/order/service/TestOrderProcessorService.java
+++ b/hni-order/src/test/java/org/hni/order/service/TestOrderProcessorService.java
@@ -86,12 +86,21 @@ public class TestOrderProcessorService {
 
 	@Test
 	public void testStatusOnCompletedOrder() {
-		User user = new User();
+		User user = new User(11L);
 		logger.debug(" ##### testStatusOnCompletedOrder ##### ");
-		user.setId(11L);
 
 		String message = orderProcessor.processMessage(user, "STATUS");
 		logger.debug(message);
-	
+
+		Assert.assertEquals(String.format(DefaultOrderProcessor.REPLY_ORDER_READY, "10790 parkridge blvd", "reston", "va"), message);
+	}
+
+	@Test
+	public void testCreateOrderWithOneOpen() {
+		User user = new User(14L);
+
+		String message = orderProcessor.processMessage(user, "MEAL");
+
+		Assert.assertEquals(DefaultOrderProcessor.REPLY_CURRENT_PENDING_ORDER, message);
 	}
 }

--- a/hni-schema/src/test/resources/hsql/test-data.sql
+++ b/hni-schema/src/test/resources/hsql/test-data.sql
@@ -14,6 +14,7 @@ insert into users values(10, 'Client', 'HasMoreOrders', 'F', '123-456-7830', '' 
 insert into users values(11, 'Privacy', 'Hogg', 'M', '123-456-7830', '' ,0, '', '', now(), '0');
 insert into users values(12, 'OrderedYesterday', 'OneAuthCode', 'M', '123-456-7830', '' ,0, '', '', now(), '0');
 insert into users values(13, 'OrderedRecently', 'OneAuthCode', 'M', '123-456-7830', '' ,0, '', '', now(), '0');
+insert into users values(14, 'OrderOpen', 'OneAuthCode', 'M', '123-456-7830', '' ,0, '', '', now(), '0');
 
 truncate table organizations;
 insert into organizations values(1, 'Not Impossible', 'phone', 'ni@email.net', 'website', 'logo', now(), 1);
@@ -58,6 +59,8 @@ insert into orders values(5, 10, 1, dateadd('HOUR', -8, now()), now(), null, 9.9
 insert into orders values(6, 11, 1, dateadd('HOUR', -8, now()), now(), null, 9.95, 1.20, 1, 2);
 insert into orders values(7, 12, 1, dateadd('DAY', -1, now()), now(), null, 9.95, 1.20, 1, 2);
 insert into orders values(8, 13, 1, formatdatetime(now(), 'yyyy-MM-dd 11:30:00'), now(), null, 9.95, 1.20, 1, 2);
+insert into orders values(9, 13, 1, formatdatetime(now(), 'yyyy-MM-dd 11:30:00'), now(), null, 9.95, 1.20, 1, 2);
+insert into orders values(10, 14, 1, formatdatetime(now(), 'yyyy-MM-dd 11:30:00'), now(), null, 9.95, 1.20, 1, 1);
 
 truncate table order_items;
 insert into order_items values(null, 1, 1, 1, 6.99);


### PR DESCRIPTION
issue #151 , check if there are pending orders when a user attempts to start a new MEAL workflow. If so, do not begin a new workflow and return a message indicating so.